### PR TITLE
Batch requests in memory

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -34,11 +34,6 @@ func NewBatchingHook(groupName, streamName string, cfg *aws.Config, batchFrequen
 		streamName: streamName,
 	}
 
-	if batchFrequency > 0 {
-		h.ch = make(chan *cloudwatchlogs.InputLogEvent, 10000)
-		go h.putBatches(time.Tick(batchFrequency))
-	}
-
 	resp, err := h.svc.DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
 		LogGroupName:        aws.String(h.groupName), // Required
 		LogStreamNamePrefix: aws.String(h.streamName),
@@ -61,6 +56,11 @@ func NewBatchingHook(groupName, streamName string, cfg *aws.Config, batchFrequen
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	if batchFrequency > 0 {
+		h.ch = make(chan *cloudwatchlogs.InputLogEvent, 10000)
+		go h.putBatches(time.Tick(batchFrequency))
 	}
 
 	return h, nil

--- a/hook_test.go
+++ b/hook_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 
+	"time"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -77,6 +79,51 @@ func TestConcurrentHook(t *testing.T) {
 	cfg := aws.NewConfig().WithRegion("us-east-1").WithCredentials(cred)
 
 	hook, err := NewHook(group, stream, cfg)
+	a.So(err, should.BeNil)
+	a.So(hook, should.NotBeNil)
+
+	l := logrus.New()
+	l.Hooks.Add(hook)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := hook.Write([]byte("TestConcurrentHook"))
+			a.So(err, should.BeNil)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestBatching(t *testing.T) {
+	a := assertions.New(t)
+
+	key := os.Getenv("AWS_ACCESS_KEY")
+	secret := os.Getenv("AWS_SECRET_KEY")
+	group := os.Getenv("AWS_CLOUDWATCHLOGS_GROUP_NAME")
+	stream := os.Getenv("AWS_CLOUDWATCHLOGS_STREAM_NAME")
+
+	if key == "" {
+		t.Skip("skipping test; AWS_ACCESS_KEY not set")
+	}
+	if secret == "" {
+		t.Skip("skipping test; AWS_SECRET_KEY not set")
+	}
+	if group == "" {
+		t.Skip("skipping test; AWS_CLOUDWATCHLOGS_GROUP_NAME not set")
+	}
+	if stream == "" {
+		t.Skip("skipping test; AWS_CLOUDWATCHLOGS_STREAM_NAME not set")
+	}
+
+	// logs.us-east-1.amazonaws.com
+	cred := credentials.NewStaticCredentials(key, secret, "")
+	cfg := aws.NewConfig().WithRegion("us-east-1").WithCredentials(cred)
+
+	hook, err := NewBatchingHook(group, stream, cfg, 100*time.Millisecond)
 	a.So(err, should.BeNil)
 	a.So(hook, should.NotBeNil)
 


### PR DESCRIPTION
This can be useful if an application produces
logs at a high rate, since the Cloudwatch Logs
service limits calls to 5 per second.