### PR TITLE
Fix Batching: limit by size/request interval, fix error return, fix b…

### DIFF
--- a/examples/batch/batch.go
+++ b/examples/batch/batch.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/kdar/logrus-cloudwatchlogs"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	key := os.Getenv("AWS_ACCESS_KEY")
+	secret := os.Getenv("AWS_SECRET_KEY")
+	group := os.Getenv("AWS_CLOUDWATCHLOGS_GROUP_NAME")
+	stream := os.Getenv("AWS_CLOUDWATCHLOGS_STREAM_NAME")
+
+	// logs.us-east-1.amazonaws.com
+	cred := credentials.NewStaticCredentials(key, secret, "")
+	cfg := aws.NewConfig().WithRegion("us-east-1").WithCredentials(cred)
+
+	//Sends log events every 200 milliseconds (AWS throttles at 5 requests per second per log stream)
+	hook, err := logrus_cloudwatchlogs.NewHookWithDuration(group, stream, cfg, 200 * time.Millisecond))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	l := logrus.New()
+	l.Hooks.Add(hook)
+	l.Out = ioutil.Discard
+	l.Formatter = logrus_cloudwatchlogs.NewProdFormatter()
+
+	l.WithFields(logrus.Fields{
+		"event": "testevent",
+		"topic": "testtopic",
+		"key":   "testkey",
+	}).Fatal("Some fatal event")
+}


### PR DESCRIPTION
…atching not occuring when log streeam already exists

This PR fixes issues that prevent batching from occurring, current issues are:
1: Error channel is using old method that prevents it from ever returning
2: Maximum batch sizes (1mb) were not respected so batches could be rejected by AWS
3: Batching would not occur if log stream already existed
4: No method existed to set batching interval without modifying the gomodule

This fix adds the method 'NewHookWithDuration' to specify a maximum duration between batches. It respects the maximum batch size by sending batches when 1mb is reached or the maximum duration is reached. Removes the old error channel and returns the last error that occurred if an error exists. Adds a batch example showing how to set the duration between batches being sent.

Current functionality of 'NewHook' remains unchanged and does not utilize batching. 