### PR TITLE
Reference lastErr address so it prints a string

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -175,7 +175,7 @@ func (h *Hook) Write(p []byte) (n int, err error) {
 		if h.err != nil {
 			lastErr := h.err
 			h.err = nil
-			return 0, fmt.Errorf("%v", lastErr)
+			return 0, fmt.Errorf("%v", *lastErr)
 		}
 		return len(p), nil
 	}


### PR DESCRIPTION
If we don't see what's in the h.err memory address all we'll get is the
actual hex code. This change makes it so that we actually print the err
located at that address rather than the hex code.

Before:
  0xc23894098
After:
  "InvalidSequenceToken: ..some data"